### PR TITLE
DEVPROD-31440: Update ENUMs and generator script to allow duplicate ENUMs

### DIFF
--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -62,5 +62,4 @@ model_test_result.go
 model_test_state_info.go
 model_validation_error.go
 response.go
-test/api_baseline_test.go
 utils.go

--- a/model_comparison_status.go
+++ b/model_comparison_status.go
@@ -20,10 +20,10 @@ type ComparisonStatus string
 
 // List of ComparisonStatus
 const (
-	PENDING ComparisonStatus = "pending"
-	COMPUTING_METRICS ComparisonStatus = "computing_metrics"
-	COMPLETE ComparisonStatus = "complete"
-	FAILED ComparisonStatus = "failed"
+	COMPARISONSTATUS_PENDING ComparisonStatus = "pending"
+	COMPARISONSTATUS_COMPUTING_METRICS ComparisonStatus = "computing_metrics"
+	COMPARISONSTATUS_COMPLETE ComparisonStatus = "complete"
+	COMPARISONSTATUS_FAILED ComparisonStatus = "failed"
 )
 
 // All allowed values of ComparisonStatus enum

--- a/model_expected_outcome.go
+++ b/model_expected_outcome.go
@@ -20,9 +20,9 @@ type ExpectedOutcome string
 
 // List of ExpectedOutcome
 const (
-	SUCCESS ExpectedOutcome = "success"
-	FAILURE ExpectedOutcome = "failure"
-	UNKNOWN ExpectedOutcome = "unknown"
+	EXPECTEDOUTCOME_SUCCESS ExpectedOutcome = "success"
+	EXPECTEDOUTCOME_FAILURE ExpectedOutcome = "failure"
+	EXPECTEDOUTCOME_UNKNOWN ExpectedOutcome = "unknown"
 )
 
 // All allowed values of ExpectedOutcome enum

--- a/model_known_issue_source.go
+++ b/model_known_issue_source.go
@@ -20,10 +20,10 @@ type KnownIssueSource string
 
 // List of KnownIssueSource
 const (
-	TEST_REGISTRY KnownIssueSource = "test_registry"
-	BUILD_BARON KnownIssueSource = "build_baron"
-	FOLIAGE KnownIssueSource = "foliage"
-	EVERGREEN KnownIssueSource = "evergreen"
+	KNOWNISSUESOURCE_TEST_REGISTRY KnownIssueSource = "test_registry"
+	KNOWNISSUESOURCE_BUILD_BARON KnownIssueSource = "build_baron"
+	KNOWNISSUESOURCE_FOLIAGE KnownIssueSource = "foliage"
+	KNOWNISSUESOURCE_EVERGREEN KnownIssueSource = "evergreen"
 )
 
 // All allowed values of KnownIssueSource enum

--- a/model_state_machine_enum.go
+++ b/model_state_machine_enum.go
@@ -20,13 +20,13 @@ type StateMachineEnum string
 
 // List of StateMachineEnum
 const (
-	N StateMachineEnum = "n"
-	STRESS_TESTING StateMachineEnum = "stress_testing"
-	STABLE StateMachineEnum = "stable"
-	DELETED StateMachineEnum = "deleted"
-	SUSPECTED_FLAKY StateMachineEnum = "suspected_flaky"
-	QUARANTINED StateMachineEnum = "quarantined"
-	MANUALLY_QUARANTINED StateMachineEnum = "manually_quarantined"
+	STATEMACHINEENUM_N StateMachineEnum = "n"
+	STATEMACHINEENUM_STRESS_TESTING StateMachineEnum = "stress_testing"
+	STATEMACHINEENUM_STABLE StateMachineEnum = "stable"
+	STATEMACHINEENUM_DELETED StateMachineEnum = "deleted"
+	STATEMACHINEENUM_SUSPECTED_FLAKY StateMachineEnum = "suspected_flaky"
+	STATEMACHINEENUM_QUARANTINED StateMachineEnum = "quarantined"
+	STATEMACHINEENUM_MANUALLY_QUARANTINED StateMachineEnum = "manually_quarantined"
 )
 
 // All allowed values of StateMachineEnum enum

--- a/model_strategy_enum.go
+++ b/model_strategy_enum.go
@@ -20,12 +20,12 @@ type StrategyEnum string
 
 // List of StrategyEnum
 const (
-	EXCLUDE_MANUALLY_QUARANTINED StrategyEnum = "ExcludeManuallyQuarantined"
-	EXISTENTIAL StrategyEnum = "Existential"
-	NOT_FAILING StrategyEnum = "NotFailing"
-	NOT_PASSING StrategyEnum = "NotPassing"
-	OPTIMISTIC StrategyEnum = "Optimistic"
-	STARTS_WITH_T StrategyEnum = "StartsWithT"
+	STRATEGYENUM_EXCLUDE_MANUALLY_QUARANTINED StrategyEnum = "ExcludeManuallyQuarantined"
+	STRATEGYENUM_EXISTENTIAL StrategyEnum = "Existential"
+	STRATEGYENUM_NOT_FAILING StrategyEnum = "NotFailing"
+	STRATEGYENUM_NOT_PASSING StrategyEnum = "NotPassing"
+	STRATEGYENUM_OPTIMISTIC StrategyEnum = "Optimistic"
+	STRATEGYENUM_STARTS_WITH_T StrategyEnum = "StartsWithT"
 )
 
 // All allowed values of StrategyEnum enum

--- a/model_test_classification.go
+++ b/model_test_classification.go
@@ -20,11 +20,11 @@ type TestClassification string
 
 // List of TestClassification
 const (
-	TRUE_POSITIVE TestClassification = "true_positive"
-	FALSE_POSITIVE TestClassification = "false_positive"
-	TRUE_NEGATIVE TestClassification = "true_negative"
-	FALSE_NEGATIVE TestClassification = "false_negative"
-	UNKNOWN TestClassification = "unknown"
+	TESTCLASSIFICATION_TRUE_POSITIVE TestClassification = "true_positive"
+	TESTCLASSIFICATION_FALSE_POSITIVE TestClassification = "false_positive"
+	TESTCLASSIFICATION_TRUE_NEGATIVE TestClassification = "true_negative"
+	TESTCLASSIFICATION_FALSE_NEGATIVE TestClassification = "false_negative"
+	TESTCLASSIFICATION_UNKNOWN TestClassification = "unknown"
 )
 
 // All allowed values of TestClassification enum

--- a/scripts/generate-openapi-client.sh
+++ b/scripts/generate-openapi-client.sh
@@ -21,4 +21,4 @@ cd ..
 export PATH="${PWD}/bin/apache-maven-${maven_version}/bin":"${PATH}"
 export PATH=/opt/bin/java/jdk21/bin:"${PATH}"
 # It's assumed that the latest JSON spec is downloaded locally in bin/test_selection_services.json.
-bin/openapi-generator-cli.sh generate -i bin/test_selection_services.json -g go -o ./ --git-user-id evergreen-ci --git-repo-id test-selection-client
+bin/openapi-generator-cli.sh generate -i bin/test_selection_services.json -g go -o ./ --git-user-id evergreen-ci --git-repo-id test-selection-client --additional-properties=enumClassPrefix=true

--- a/scripts/generate-openapi-client.sh
+++ b/scripts/generate-openapi-client.sh
@@ -21,4 +21,6 @@ cd ..
 export PATH="${PWD}/bin/apache-maven-${maven_version}/bin":"${PATH}"
 export PATH=/opt/bin/java/jdk21/bin:"${PATH}"
 # It's assumed that the latest JSON spec is downloaded locally in bin/test_selection_services.json.
+# enumClassPrefix=true prefixes enum constants with their type name to avoid duplicate
+# identifiers in Go (e.g. multiple enums defining "UNKNOWN").
 bin/openapi-generator-cli.sh generate -i bin/test_selection_services.json -g go -o ./ --git-user-id evergreen-ci --git-repo-id test-selection-client --additional-properties=enumClassPrefix=true


### PR DESCRIPTION
- Add enumClassPrefix=true to the OpenAPI generator to prevent duplicate constant names across enum types
  (e.g. UNKNOWN was generated in both ExpectedOutcome and TestClassification, which doesn't compile in Go)
- Regenerated ENUMs